### PR TITLE
Using weak pointers and shared pointers in the linked list

### DIFF
--- a/include/yall.hpp
+++ b/include/yall.hpp
@@ -44,7 +44,7 @@ namespace yall {
       if (head) {
         node_ptr->next = head;
         head->prev     = node_ptr;
-        head = node_ptr;
+        head           = node_ptr;
       } else {
         head = node_ptr;
         tail = node_ptr;
@@ -58,7 +58,7 @@ namespace yall {
       if (auto old_tail = tail.lock()) {
         node_ptr->prev = old_tail;
         old_tail->next = node_ptr;
-        tail = node_ptr;
+        tail           = node_ptr;
       } else {
         head = node_ptr;
         tail = node_ptr;

--- a/test/yall_test.cpp
+++ b/test/yall_test.cpp
@@ -6,24 +6,50 @@ TEST(YallTest, FrontPushPop) {
   constexpr size_t sz = 101;
   int test_arr[sz];
 
-  std::iota(test_arr, test_arr+sz, 0);
+  std::iota(test_arr, test_arr + sz, 0);
 
   yall::Yall<int&> dlist;
   EXPECT_FALSE(dlist.front_val().has_value());
   EXPECT_TRUE(dlist.empty());
 
-  for (auto& val : test_arr) {
+  for (auto& val: test_arr) {
     dlist.push_front(val);
   }
   EXPECT_FALSE(dlist.empty());
 
-  for (int i=sz-1; i>=0; --i) {
-    auto val = test_arr[i];
+  for (int i = sz - 1; i >= 0; --i) {
+    auto val      = test_arr[i];
     auto test_val = dlist.front_val();
     EXPECT_TRUE(test_val.has_value());
-    EXPECT_EQ(test_val.value(),val);
+    EXPECT_EQ(test_val.value(), val);
 
     dlist.pop_front();
+  }
+  EXPECT_TRUE(dlist.empty());
+}
+
+TEST(YallTest, BackPushPop) {
+  constexpr size_t sz = 101;
+  int test_arr[sz];
+
+  std::iota(test_arr, test_arr + sz, 0);
+
+  yall::Yall<int&> dlist;
+  EXPECT_FALSE(dlist.back_val().has_value());
+  EXPECT_TRUE(dlist.empty());
+
+  for (auto& val: test_arr) {
+    dlist.push_back(val);
+  }
+  EXPECT_FALSE(dlist.empty());
+
+  for (int i = sz - 1; i >= 0; --i) {
+    auto val      = test_arr[i];
+    auto test_val = dlist.back_val();
+    EXPECT_TRUE(test_val.has_value());
+    EXPECT_EQ(test_val.value(), val);
+
+    dlist.pop_back();
   }
   EXPECT_TRUE(dlist.empty());
 }
@@ -32,30 +58,30 @@ TEST(YallTest, RemoveFirst) {
   constexpr size_t sz = 101;
   double test_arr[sz];
 
-  std::iota(test_arr, test_arr+sz, -999.0);
+  std::iota(test_arr, test_arr + sz, -999.0);
 
   yall::Yall<double&> dlist;
 
   // index of to be removed
-  constexpr size_t rmv_indx = sz/3;
+  constexpr size_t rmv_indx = sz / 3;
   // test with empty list
   EXPECT_FALSE(dlist.remove_first(test_arr[rmv_indx]));
 
-  for (auto& val : test_arr) {
+  for (auto& val: test_arr) {
     dlist.push_front(val);
   }
 
   EXPECT_TRUE(dlist.remove_first(test_arr[rmv_indx]));
 
-  for (int i=sz-1; i>=0; --i) {
-    auto val = test_arr[i];
+  for (int i = sz - 1; i >= 0; --i) {
+    auto val      = test_arr[i];
     auto test_val = dlist.front_val();
     EXPECT_TRUE(test_val.has_value());
     if (i != rmv_indx) {
-      EXPECT_EQ(test_val.value(),val);
+      EXPECT_EQ(test_val.value(), val);
       dlist.pop_front();
     } else {
-      EXPECT_NE(test_val.value(),val);
+      EXPECT_NE(test_val.value(), val);
     }
   }
 }
@@ -64,41 +90,41 @@ TEST(YallTest, RemoveLast) {
   constexpr size_t sz = 101;
   double test_arr[sz];
 
-  std::iota(test_arr, test_arr+sz, -999.0);
+  std::iota(test_arr, test_arr + sz, -999.0);
 
   yall::Yall<double&> dlist;
 
   // index of to be removed
-  constexpr size_t rmv_indx = sz/3;
+  constexpr size_t rmv_indx = sz / 3;
   // test with empty list
   EXPECT_FALSE(dlist.remove_last(test_arr[rmv_indx]));
 
-  for (auto& val : test_arr) {
+  for (auto& val: test_arr) {
     dlist.push_front(val);
   }
 
   EXPECT_TRUE(dlist.remove_last(test_arr[rmv_indx]));
 
-  for (int i=sz-1; i>=0; --i) {
-    auto val = test_arr[i];
+  for (int i = sz - 1; i >= 0; --i) {
+    auto val      = test_arr[i];
     auto test_val = dlist.front_val();
     EXPECT_TRUE(test_val.has_value());
-    if ( i != rmv_indx) {
-      EXPECT_EQ(test_val.value(),val);
+    if (i != rmv_indx) {
+      EXPECT_EQ(test_val.value(), val);
       dlist.pop_front();
     } else {
-      EXPECT_NE(test_val.value(),val);
+      EXPECT_NE(test_val.value(), val);
     }
   }
 
   dlist.reset();
   double test_val = 3.14;
 
-  for (auto i=0UL; i<sz; ++i) {
+  for (auto i = 0UL; i < sz; ++i) {
     dlist.push_front(test_val);
   }
 
-  for (auto i=0UL; i<sz; ++i) {
+  for (auto i = 0UL; i < sz; ++i) {
     EXPECT_TRUE(dlist.remove_last(test_val));
   }
   // list should be empty
@@ -110,29 +136,72 @@ TEST(YallTest, Reset) {
   constexpr size_t sz = 11;
   unsigned long test_arr[sz];
 
-  std::iota(test_arr, test_arr+sz, 0);
+  std::iota(test_arr, test_arr + sz, 0);
 
   yall::Yall<unsigned long&> ul_list;
   EXPECT_FALSE(ul_list.front_val().has_value());
   EXPECT_FALSE(ul_list.back_val().has_value());
+  EXPECT_TRUE(ul_list.empty());
 
-  for (auto& val : test_arr) {
+  for (auto& val: test_arr) {
     ul_list.push_back(val);
   }
   EXPECT_TRUE(ul_list.front_val().has_value());
   EXPECT_TRUE(ul_list.back_val().has_value());
+  EXPECT_FALSE(ul_list.empty());
 
   ul_list.reset();
   EXPECT_FALSE(ul_list.front_val().has_value());
   EXPECT_FALSE(ul_list.back_val().has_value());
+  EXPECT_TRUE(ul_list.empty());
+}
+
+TEST(YallTest, SingleVal) {
+  float test_val = 42.0f;
+
+  yall::Yall<float&> ref_list;
+
+  ref_list.push_front(test_val);
+  ASSERT_EQ(ref_list.front_val(), test_val);
+  ASSERT_EQ(ref_list.back_val(), test_val);
+
+  yall::Yall<float> val_list;
+
+  val_list.push_back(test_val);
+  ASSERT_EQ(val_list.front_val(), test_val);
+  ASSERT_EQ(val_list.back_val(), test_val);
+
+  test_val = 13.0f;
+  ASSERT_EQ(ref_list.front_val(), test_val);
+  ASSERT_EQ(ref_list.back_val(), test_val);
+  // the value list stored a copy of the test value
+  ASSERT_NE(val_list.front_val(), test_val);
+  ASSERT_NE(val_list.back_val(), test_val);
+}
+
+TEST(YallTest, ConstSingleVal) {
+  const float test_val = 42.0f;
+
+  yall::Yall<const float&> flist1;
+
+  flist1.push_front(test_val);
+  ASSERT_EQ(flist1.front_val(), test_val);
+  ASSERT_EQ(flist1.back_val(), test_val);
+
+  yall::Yall<const float> flist2;
+
+  flist2.push_back(test_val);
+  ASSERT_EQ(flist2.front_val(), test_val);
+  ASSERT_EQ(flist2.back_val(), test_val);
 }
 
 TEST(YallTest, FrontBack) {
   class Clazz {
     int data;
+
   public:
     explicit Clazz(int n) : data(n) {}
-    int get() const {return data;}
+    int get() const { return data; }
   };
 
   Clazz obj1(1);


### PR DESCRIPTION
- The `next` pointers are shared pointers, the `prev` pointers are weak pointers
- Circular shared_ptr references are removed, custom destructor is removed, and RAII is maintained 
- Added more unit tests